### PR TITLE
fix(front): layout improvements [EV-60][EV-62][EV-63]

### DIFF
--- a/src/containers/Projects/Screens/Project/Project.tsx
+++ b/src/containers/Projects/Screens/Project/Project.tsx
@@ -46,6 +46,7 @@ export const Project = () => {
   const { data: project, status } = useFetchProjectDetail(projectId)
 
   useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const _eventListener = (e) => {
       const visiblePercentages = NAV_SECTIONS.map(({ name }) => {
         const visiblePercentage = calculateVisiblePercentage(`#${name}`)

--- a/src/containers/Projects/Screens/Project/components/ImpactTabs/ImpactTabs.styles.ts
+++ b/src/containers/Projects/Screens/Project/components/ImpactTabs/ImpactTabs.styles.ts
@@ -69,7 +69,8 @@ export const TabContent = styled('div', {
   marginTop: '$14',
 
   '@bp2': {
-    display: 'flex',
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
     justifyContent: 'space-between',
     alignItems: 'center',
   },
@@ -77,8 +78,7 @@ export const TabContent = styled('div', {
 
 export const TabImage = styled('figure', {
   position: 'relative',
-  height: '380px',
-  width: '273px',
+  height: '100%',
   margin: 'auto',
 
   '@bp2': {

--- a/src/containers/Projects/Screens/Project/components/ImpactTabs/ImpactTabs.tsx
+++ b/src/containers/Projects/Screens/Project/components/ImpactTabs/ImpactTabs.tsx
@@ -155,7 +155,7 @@ export const ImpactTabs = ({ impact }: ImpactTabsProps) => {
       {tabsSections?.map(({ title: sectionTitle, subtitle, description, photo }) => (
         <TabContainer key={sectionTitle} value={sectionTitle}>
           <Text
-            size={{ '@mobile': 'h3', '@bp2': 'h2' }}
+            size={{ '@mobile': 'h3', '@bp2': 'h3' }}
             family="secondary"
             color="primary-tuna-500"
             dangerouslySetInnerHTML={{ __html: subtitle }}

--- a/src/containers/Projects/Screens/Project/components/ImpactTabs/ImpactTabs.tsx
+++ b/src/containers/Projects/Screens/Project/components/ImpactTabs/ImpactTabs.tsx
@@ -79,6 +79,7 @@ export const ImpactTabs = ({ impact }: ImpactTabsProps) => {
     observer.observe(dropdownRef.current)
 
     return () => observer.disconnect()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dropdownRef.current])
 
   const tabsSections = tabs?.reduce((acc: TabSection[], { sections }) => {
@@ -167,7 +168,7 @@ export const ImpactTabs = ({ impact }: ImpactTabsProps) => {
             </TabContentText>
             {photo && (
               <TabImage>
-                <Image src={photo.url} alt={photo.altText} layout="fill" objectFit="cover" />
+                <Image src={photo.url} alt={photo.altText} layout="fill" objectFit="contain" />
               </TabImage>
             )}
           </TabContent>


### PR DESCRIPTION
## Description
This PR fixes next issues on project detail page

- Decrease subtitle size on desktop
- Adjust images on Impact section to avoid extra space between image and text.

![Screenshot 2022-05-30 at 11 39 39](https://user-images.githubusercontent.com/51995866/170966060-8c0f63ad-cfb5-4855-8577-4d24f1095692.png)
![Screenshot 2022-05-30 at 11 39 24](https://user-images.githubusercontent.com/51995866/170966088-9af34436-d3ce-4759-982d-49d9a8d7aa77.png)

## Testing instructions
Make sure all images display correctly by entering projects with portrait and landscape images

## Tracking
[EV-60](https://vizzuality.atlassian.net/browse/EV-60)
